### PR TITLE
Newlib local patch: Add weak symbols for locking functions

### DIFF
--- a/local-patches/newlib/2.0.0/0004-weak-locking.patch
+++ b/local-patches/newlib/2.0.0/0004-weak-locking.patch
@@ -1,0 +1,117 @@
+1;3603;0cIndex: newlib-2.0.0/newlib/libc/sys/xtensa/Makefile.am
+===================================================================
+--- newlib-2.0.0.orig/newlib/libc/sys/xtensa/Makefile.am
++++ newlib-2.0.0/newlib/libc/sys/xtensa/Makefile.am
+@@ -6,7 +6,7 @@ INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLA
+ 
+ noinst_LIBRARIES = lib.a
+ 
+-lib_a_SOURCES = _atexit.c creat.c isatty.c clibrary_init.c
++lib_a_SOURCES = _atexit.c creat.c isatty.c clibrary_init.c lock.c
+ 
+ all: crt0.o
+ 
+Index: newlib-2.0.0/newlib/libc/sys/xtensa/lock.c
+===================================================================
+--- /dev/null
++++ newlib-2.0.0/newlib/libc/sys/xtensa/lock.c
+@@ -0,0 +1,22 @@
++/* Weak-linked stub locking functions.
++
++   Intended that you can replace the _lock_xxx functions with your own
++   lock implementation at link time, if needed.
++
++   See comments in sys/lock.h for notes about lock initialization.
++*/
++#include <sys/lock.h>
++
++void __dummy_lock(_lock_t *lock) { }
++int __dummy_lock_try(_lock_t *lock) { return 0; }
++
++void _lock_init(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
++void _lock_init_recursive(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
++void _lock_close(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
++void _lock_close_recursive(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
++void _lock_acquire(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
++void _lock_acquire_recursive(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
++int _lock_try_acquire(_lock_t *lock) __attribute__((weak, alias("__dummy_lock_try")));
++int _lock_try_acquire_recursive(_lock_t *lock) __attribute__((weak, alias("__dummy_lock_try")));
++void _lock_release(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
++void _lock_release_recursive(_lock_t *lock) __attribute__((weak, alias("__dummy_lock")));
+Index: newlib-2.0.0/newlib/libc/sys/xtensa/sys/lock.h
+===================================================================
+--- /dev/null
++++ newlib-2.0.0/newlib/libc/sys/xtensa/sys/lock.h
+@@ -0,0 +1,50 @@
++#ifndef _XTENSA_LOCK_H__
++#define _XTENSA_LOCK_H__
++
++/* generic lock implementation.
++
++   Weak linked stub _lock functions in lock.c, can be
++   replaced with a lock implementation at link time.
++
++ */
++
++typedef int _lock_t;
++typedef _lock_t _LOCK_RECURSIVE_T;
++typedef _lock_t _LOCK_T;
++
++#include <_ansi.h>
++
++/* NOTE: some parts of newlib statically initialise locks via
++   __LOCK_INIT, some initialise at runtime via __lock_init. So need to
++   support possibility that a _lock_t is null during first call to
++   _lock_acquire or _lock_try_acquire.
++
++   Lock functions all take a pointer to the _lock_t entry, so the
++   value stored there can be manipulated.
++*/
++#define __LOCK_INIT(CLASS,NAME) CLASS _lock_t NAME = 0;
++#define __LOCK_INIT_RECURSIVE(CLASS,NAME) CLASS _lock_t NAME = 0;
++
++void _lock_init(_lock_t *lock);
++void _lock_init_recursive(_lock_t *lock);
++void _lock_close(_lock_t *lock);
++void _lock_close_recursive(_lock_t *lock);
++void _lock_acquire(_lock_t *lock);
++void _lock_acquire_recursive(_lock_t *lock);
++int _lock_try_acquire(_lock_t *lock);
++int _lock_try_acquire_recursive(_lock_t *lock);
++void _lock_release(_lock_t *lock);
++void _lock_release_recursive(_lock_t *lock);
++
++#define __lock_init(lock) _lock_init(&(lock))
++#define __lock_init_recursive(lock) _lock_recursive_init(&(lock))
++#define __lock_close(lock) _lock_close(&(lock))
++#define __lock_close_recursive(lock) _lock_close_recursive(&(lock))
++#define __lock_acquire(lock) _lock_acquire(&(lock))
++#define __lock_acquire_recursive(lock) _lock_acquire_recursive(&(lock))
++#define __lock_try_acquire(lock) _lock_try_acquire(&(lock))
++#define __lock_try_acquire_recursive(lock) _lock_acquire_recursive(&(lock))
++#define __lock_release(lock) _lock_release(&(lock))
++#define __lock_release_recursive(lock) _lock_release_recursive(&(lock))
++
++#endif /* _XTENSA_LOCK_H__ */
+Index: newlib-2.0.0/newlib/libc/sys/xtensa/Makefile.in
+===================================================================
+--- newlib-2.0.0.orig/newlib/libc/sys/xtensa/Makefile.in
++++ newlib-2.0.0/newlib/libc/sys/xtensa/Makefile.in
+@@ -57,7 +57,7 @@ ARFLAGS = cru
+ lib_a_AR = $(AR) $(ARFLAGS)
+ lib_a_LIBADD =
+ am_lib_a_OBJECTS = _atexit.$(OBJEXT) creat.$(OBJEXT) isatty.$(OBJEXT) \
+-	clibrary_init.$(OBJEXT)
++	clibrary_init.$(OBJEXT) lock.$(OBJEXT)
+ lib_a_OBJECTS = $(am_lib_a_OBJECTS)
+ DEFAULT_INCLUDES = -I. -I$(srcdir)
+ depcomp =
+@@ -184,7 +184,7 @@ target_alias = @target_alias@
+ AUTOMAKE_OPTIONS = cygnus
+ INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
+ noinst_LIBRARIES = lib.a
+-lib_a_SOURCES = _atexit.c creat.c isatty.c clibrary_init.c
++lib_a_SOURCES = _atexit.c creat.c isatty.c clibrary_init.c lock.c
+ ACLOCAL_AMFLAGS = -I ../../..
+ CONFIG_STATUS_DEPENDENCIES = $(newlib_basedir)/configure.host
+ all: all-am


### PR DESCRIPTION
Hi Max,

I don't know how you'll feel about this patch, but I thought I'd ask. It lets me produce a thread safe newlib that I can link with FreeRTOS' locking primitives for esp-open-rtos.

There might be a better way to do this that I don't know of. Most of the people using FreeRTOS with newlib seem to just modify it directly and compile a FreeRTOS-specific libc, but I figured that was a last resort.

Cheers,


Angus

***

This allows a lock implementation to be optionally added at link time.

Small performance hit if using single threaded, in that locks are now a
call to a no-op dummy function rather than a compiled in no-op.