### PR TITLE
Allow installing crosstools outside src tree

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -310,7 +310,7 @@ install-lib: $(DESTDIR)$(libdir)    \
              install-lib-main       \
              install-lib-samples
 
-LIB_SUB_DIR := config contrib patches scripts
+LIB_SUB_DIR := config contrib local-patches overlays patches scripts
 $(patsubst %,install-lib-%-copy,$(LIB_SUB_DIR)): $(DESTDIR)$(libdir)
 	@echo "  INSTDIR '$(patsubst install-lib-%-copy,%,$(@))/'"
 	@tar cf - --exclude='*.sh.in' $(patsubst install-lib-%-copy,%,$(@)) \


### PR DESCRIPTION
If crosstools are installed in a directory different from the source directory and a toolchain for e.g. xtensa-esp108-elf is to be build, then two additional directories need to be copied to the installation: local-patches and overlays.