### PR TITLE
-DMALLOC_PROVIDED added to newlib flags

### DIFF
--- a/local-patches/newlib/2.0.0/0001-xtensa-add-port.patch
+++ b/local-patches/newlib/2.0.0/0001-xtensa-add-port.patch
@@ -583,7 +583,7 @@ diff --git a/newlib/configure.host b/newlib/configure.host
 index f1e1309..de19d18 100644
 --- a/newlib/configure.host
 +++ b/newlib/configure.host
-@@ -282,6 +282,12 @@ case "${host_cpu}" in
+@@ -282,6 +282,13 @@ case "${host_cpu}" in
  	newlib_cflags="${newlib_cflags} -DMALLOC_PROVIDED"
  	newlib_cflags="${newlib_cflags} -DPREFER_SIZE_OVER_SPEED"
          ;;
@@ -592,6 +592,7 @@ index f1e1309..de19d18 100644
 +	machine_dir=xtensa
 +	newlib_cflags="${newlib_cflags} -mlongcalls"
 +	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED"
++ 	newlib_cflags="${newlib_cflags} -DMALLOC_PROVIDED"
 +        ;;
    z8k)
  	machine_dir=z8k


### PR DESCRIPTION
malloc implementation in newlib doesn't seem to have much value. Сontrariwise, since Espressif SDK has own memory manager routines using the newlib ones may cause bad things to happen.

Excluding memory management routines from newlib worth doing anyway (using them or functions depending on them make linker fail with unresolved externals).

In order to mitigate this and let devs use even those functions I plan to do a lib providing malloc/calloc/free and syscall implementations for esp-open-sdk and UDK based on Espressif SDK routines to connect newlib to the Espressif platform. 

 