### PR TITLE
Update the cloog download website

### DIFF
--- a/scripts/build/companion_libs/130-cloog.sh
+++ b/scripts/build/companion_libs/130-cloog.sh
@@ -15,7 +15,8 @@ if [ "${CT_CLOOG}" = "y" ]; then
 do_cloog_get() {
     CT_GetFile "cloog-${CT_CLOOG_VERSION}"          \
         http://www.bastoul.net/cloog/pages/download \
-        ftp://gcc.gnu.org/pub/gcc/infrastructure
+        ftp://gcc.gnu.org/pub/gcc/infrastructure    \
+        https://distfiles.macports.org/cloog
 }
 
 # Extract CLooG


### PR DESCRIPTION
www.bastoul.net seems dead and  gcc.gnu.org do not have 0.18.4.tar.gz
So the build is failing
Add an extra place to find cloog-0.18.4.tar.gz