### PR TITLE
Remove -v from strip_args

### DIFF
--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -17,7 +17,7 @@ do_finish() {
                 strip_args=""
                 ;;
             *)
-                strip_args="--strip-all -v"
+                strip_args="--strip-all"
                 ;;
         esac
         CT_DoLog INFO "Stripping all toolchain executables"


### PR DESCRIPTION
FreeBSD base `strip` (which is not Binutils `strip` but elfutils `strip`) does not not handle `-v`.

Rather than creating a separate branch for `CT_HOST *freebsd*` or merge it into `*darwin*`, just remove `-v` altogether. The output along the lines of

>  copy from \`foo' [elf64-x86-64] to `stx15vcK' [elf64-x86-64]

does not bear any real information (it's too much for a progress bar, and too little for anything else).

This makes builds on (at least) FreeBSD hosts possible.