### PR TITLE
remove 'ftp.kernel.org'

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -15,7 +15,7 @@ do_binutils_get() {
                        http://cbuild.validation.linaro.org/snapshots
         else
             CT_GetFile "binutils-${CT_BINUTILS_VERSION}"                                        \
-                       {http,ftp}://{ftp.gnu.org/gnu,ftp.kernel.org/pub/linux/devel}/binutils   \
+                       http://ftp.gnu.org/gnu/binutils                                          \
                        ftp://{sourceware.org,gcc.gnu.org}/pub/binutils/{releases,snapshots}
         fi
     fi


### PR DESCRIPTION
The kernel's ftp server ftp.kernel.org is not available anymore.
See: https://www.kernel.org/shutting-down-ftp-services.html