### PR TITLE
update source url of expat library from sourceforge to github

### DIFF
--- a/scripts/build/companion_libs/210-expat.sh
+++ b/scripts/build/companion_libs/210-expat.sh
@@ -10,7 +10,7 @@ if [ "${CT_EXPAT_TARGET}" = "y" -o "${CT_EXPAT}" = "y" ]; then
 
 do_expat_get() {
     CT_GetFile "expat-${CT_EXPAT_VERSION}" .tar.gz    \
-               http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}
+              https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//[.]/_}
 }
 
 do_expat_extract() {


### PR DESCRIPTION
expat library moved location from sourceforge to github. Even downloads were still available on sourceforge, it seems it's not reliable source anymore.

For example I am not able to download it now, and more people as well in a recent history (see pfalcon/esp-open-sdk#307 ):
```
wget http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz
```

Since it's not reliable to use sourceforge, I've update source to github in a recipe.