### PR TITLE
Add compability for bash 5 (same as #56 for other branch)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,7 @@ ACX_PROG_VERSION_REQ_STRICT([BASH_SHELL],
     [GNU bash >= 3.1],
     [bash],
     [bash],
-    ['^GNU bash, version (3\.[1-9]|4)'])
+    ['^GNU bash, version (3\.[1-9]|4|5)'])
 
 # We need a awk that *is* GNU awk
 ACX_PROG_VERSION_REQ_STRICT([AWK],


### PR DESCRIPTION
Initial reason was the issue referenced [in this PullRequest](https://github.com/jcmvbkbc/crosstool-NG/pull/56). But this fix is relevant here, too.