### PR TITLE
fix: prevent configure fail with bash 5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AC_CACHE_VAL([ac_cv_path__BASH],
 AC_CACHE_CHECK([for bash >= 3.1], [ac_cv_path__BASH],
     [AC_PATH_PROGS_FEATURE_CHECK([_BASH], [bash],
         [[_BASH_ver=$($ac_path__BASH --version 2>&1 \
-                     |$EGREP '^GNU bash, version (3\.[1-9]|4)')
+                     |$EGREP '^GNU bash, version (3\.[1-9]|4|5)')
           test -n "$_BASH_ver" && ac_cv_path__BASH=$ac_path__BASH ac_path__BASH_found=:]],
         [AC_MSG_RESULT([no])
          AC_MSG_ERROR([could not find bash >= 3.1])])])


### PR DESCRIPTION
Initial reason was the issue referenced [in this PullRequest](https://github.com/jcmvbkbc/crosstool-NG/pull/56). But this fix is relevant here, too.