### PR TITLE
Fix expat download

### DIFF
--- a/scripts/build/companion_libs/210-expat.sh
+++ b/scripts/build/companion_libs/210-expat.sh
@@ -9,8 +9,7 @@ do_expat_for_target() { :; }
 if [ "${CT_EXPAT_TARGET}" = "y" -o "${CT_EXPAT}" = "y" ]; then
 
 do_expat_get() {
-    CT_GetFile "expat-${CT_EXPAT_VERSION}" .tar.gz    \
-               http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}
+    wget "https://github.com/libexpat/libexpat/releases/download/R_2_1_0/expat-2.1.0.tar.gz"
 }
 
 do_expat_extract() {


### PR DESCRIPTION
Change the download URL since the old one doesn't work

From [this](https://github.com/pfalcon/esp-open-sdk/issues/237) issue, it should be fixed this way